### PR TITLE
Add tests of remaining functions in aggregates.py

### DIFF
--- a/open_cge/tests/test_aggregates.py
+++ b/open_cge/tests/test_aggregates.py
@@ -40,16 +40,16 @@ def test_eqKf():
     assert expected_Kf == test_Kf
 
 # Capital market clearing equation
-#def test_eqKk():
-#    pf = np.array([2, 4, 5, 1])
-#    Ff = np.array([3, 4, 5, 7])
-#    R = 0.02
-#    lam = np.array([0.3, 0.2, 0.1, 0.4])
-#    assert sum(lam) == 1
-#    pq = np.array([5, 6, 8, 4])
-#    expected_Kk = 529.41
-#    test_Kk = aggregates.eqKk(pf, Ff, R, lam, pq)
-#    assert_allclose(expected_Kk, test_Kk)
+def test_eqKk():
+    pf = pd.Series([5, 2], index = ['LAB','CAP'])
+    Ff = pd.Series([10, 20], index = ['LAB', 'CAP'])
+    R = 0.02
+    lam = np.array([0.3, 0.2, 0.1, 0.4])
+    assert sum(lam) == 1
+    pq = np.array([5, 6, 8, 4])
+    expected_Kk = 392.156863
+    test_Kk = aggregates.eqKk(pf, Ff, R, lam, pq)
+    assert_allclose(expected_Kk, test_Kk)
 
 # Balance of payments
 def test_eqbop():

--- a/open_cge/tests/test_aggregates.py
+++ b/open_cge/tests/test_aggregates.py
@@ -8,14 +8,6 @@ from pandas.testing import assert_frame_equal
 from numpy.testing import assert_allclose
 from open_cge import aggregates
 
-# Total investment
-def eqXXv():
-    g = 0.03
-    Kk = 100
-    expected_eqXXv = 3
-    test_eqXXv = aggregates.eqXXv(g, Kk)
-    assert expected_eqXXv == test_eqXXv
-
 # Total household saving
 def test_eqSp():
     ssp = 0.1
@@ -98,12 +90,31 @@ def test_eqpqerror():
 
 
 # Comparing labor supply from the model to that in the data
-#def test_eqpf():
+def test_eqpf():
+    F = pd.DataFrame.from_dict({'LAB': [10, 40], 'CAP': [30, 20]},
+    orient = 'index')
+    Ff0 = pd.Series(50, index = ['LAB', 'CAP'])
+    expected_pf_error = 0
+    test_pf_error = aggregates.eqpf(F, Ff0)
+    assert_allclose(expected_pf_error, test_pf_error)
 
 
 # Comparing capital demand in the model and data
-#def test_eqpk():
+def test_eqpk():
+    F = pd.DataFrame.from_dict({'LAB': [10, 40], 'CAP': [30, 20]},
+    orient = 'index')
+    Kk = 50
+    Ff0 = Ff0 = pd.Series(50, index = ['LAB', 'CAP'])
+    Kk0 = Ff0 = pd.Series(50, index = ['CAP'])
+    expected_pk_error = 0
+    test_pk_error = aggregates.eqpk(F, Kk, Ff0, Kk0)
+    assert_allclose(expected_pk_error, test_pk_error)
 
 
 # Total investment
-#def eqXXv():
+def eqXXv():
+    g = 0.03
+    Kk = 100
+    expected_eqXXv = 3
+    test_eqXXv = aggregates.eqXXv(g, Kk)
+    assert expected_eqXXv == test_eqXXv


### PR DESCRIPTION
@jdebacker 

This PR adds tests of 3 additional functions in aggregates.py eqpf, eqpk, and eqkk.

I ran the set of tests for CGE and added the output below.

Let me know if I need to do anything else for this PR.

=========================== test session starts ============================
platform win32 -- Python 3.7.3, pytest-4.4.0, py-1.8.0, pluggy-0.9.0 -- C:\Us
\duncan.hobbs\AppData\Local\Continuum\anaconda3\envs\cge_env\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\duncan.hobbs\Github\PSL\CGE
plugins: xdist-1.26.1, pep8-1.0.6, forked-1.0.2
collected 37 items

test_aggregates.py::test_eqSp PASSED
test_aggregates.py::test_Kd PASSED
test_aggregates.py::test_eqKf PASSED
test_aggregates.py::test_eqKk kk inputs=  2 20 0.02 [0.3 0.2 0.1 0.4] [5 6 8
PASSED
test_aggregates.py::test_eqbop PASSED
test_aggregates.py::test_eqSf 14.099999999999998
PASSED
test_aggregates.py::test_eqpqerror PASSED
test_aggregates.py::test_eqpf PASSED
test_aggregates.py::test_eqpk PASSED
test_execute.py::test_runner initial guess =  [1. 1. 1. 1. 1. 1. 1. 1.]
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0000000149011612 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  1.0 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  0.9999999999999999 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
kk inputs=  0.9999999999999999 1051.0 0.1 AGR    0.000000
OIL    0.000000
IND    0.237113
SER    0.762887
Name: INV, dtype: float64 AGR    1.0
OIL    1.0
IND    1.0
SER    1.0
dtype: float64
Distance at iteration  1  is  4.121147867408581e-12
Model solved, Q =  AGR     116.0
OIL     149.0
IND    1432.0
SER    1803.0
dtype: float64
PASSED
test_execute.py::test_check_square PASSED
test_execute.py::test_row_total PASSED
test_execute.py::test_col_total PASSED
test_execute.py::test_row_col_equal PASSED
test_firms.py::test_eqpy PASSED
test_firms.py::test_eqX PASSED
test_firms.py::test_eqY PASSED
test_firms.py::test_eqpz PASSED
test_firms.py::test_eqXv PASSED
test_firms.py::test_eqFsh PASSED
test_firms.py::test_eqpe PASSED
test_firms.py::test_eqpm PASSED
test_firms.py::test_eqQ PASSED
test_firms.py::test_eqM PASSED
test_firms.py::test_eqD PASSED
test_firms.py::test_eqpd PASSED
test_firms.py::test_eqZ PASSED
test_firms.py::test_eqE PASSED
test_firms.py::test_eqDex PASSED
test_government.py::test_eqTd PASSED
test_government.py::test_eqTz PASSED
test_government.py::test_eqTm PASSED
test_government.py::test_eqXg PASSED
test_government.py::test_eqSg PASSED
test_household.py::test_eqF Type =  <class 'pandas.core.frame.DataFrame'>
        0    1    2
Row1  0.3  0.4  0.5
Row2  0.4  0.4  0.3
Row3  0.4  0.2  0.2
PASSED
test_household.py::test_eqI Type =  <class 'numpy.int32'>
75
PASSED
test_household.py::test_eqXp Type =  <class 'pandas.core.frame.DataFrame'>
        0
Row1  0.2
Row2  0.4
Row3  0.4
PASSED

============================= warnings summary =============================
open_cge/tests/test_execute.py::test_runner
open_cge/tests/test_execute.py::test_runner
open_cge/tests/test_execute.py::test_runner
  C:\Users\duncan.hobbs\AppData\Local\Continuum\anaconda3\envs\cge_env\lib\si
packages\numpy\lib\type_check.py:546: DeprecationWarning: np.asscalar(a) is d
ecated since NumPy v1.16, use a.item() instead
    'a.item() instead', DeprecationWarning, stacklevel=1)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================== 37 passed, 3 warnings in 2.08 seconds ===================